### PR TITLE
Fix crs name conflict

### DIFF
--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set-label.yaml
@@ -4,4 +4,4 @@ metadata:
   name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
   labels:
-    cni: "${CLUSTER_NAME}-crs-0"
+    cni: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
+++ b/test/e2e/data/infrastructure-vsphere/kustomization/cluster-resource-set.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "cni-${CLUSTER_NAME}-crs-0"
+  name: "cni-${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
 metadata:
-  name:  "${CLUSTER_NAME}-crs-0"
+  name:  "${CLUSTER_NAME}-crs-cni"
 spec:
   strategy: ApplyOnce
   clusterSelector:
     matchLabels:
-      cni: "${CLUSTER_NAME}-crs-0"
+      cni: "${CLUSTER_NAME}-crs-cni"
   resources:
-    - name: "cni-${CLUSTER_NAME}-crs-0"
+    - name: "cni-${CLUSTER_NAME}-crs-cni"
       kind: ConfigMap


### PR DESCRIPTION
We weren't using crs for the ha proxy template. These changes introduced crs for ha proxy as well and the e2e tests tries to apply a crs with the same name. 

Changing the name of the crs applied by the e2e 